### PR TITLE
Add mac releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          # - ubuntu-latest
           - macos-latest
         version:
           - mini
-          - full
+          # - full
 
     steps:
       - name: "Cancel similar actions in progress"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,11 @@ jobs:
     strategy:
       matrix:
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - macos-latest
         version:
           - mini
-          # - full
+          - full
 
     steps:
       - name: "Cancel similar actions in progress"
@@ -73,11 +73,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libwebkit2gtk-4.0-dev libmpfr-dev
-
-      - name: Install dependencies (macos)
-        if: matrix.version == 'full' && matrix.os == 'ubuntu-latest'
-        run: |
-          sudo brew install gmp
 
       - name: Verify dependecies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,11 +68,16 @@ jobs:
           wget -qO - https://nim-lang.org/choosenim/init.sh | bash -s -- -y
           echo "$HOME/.nimble/bin" >> $GITHUB_PATH
 
-      - name: Install dependencies
+      - name: Install dependencies (ubuntu)
         if: matrix.version == 'full' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libwebkit2gtk-4.0-dev libmpfr-dev
+
+      - name: Install dependencies (macos)
+        if: matrix.version == 'full' && matrix.os == 'ubuntu-latest'
+        run: |
+          sudo brew install gmp
 
       - name: Verify dependecies
         run: |


### PR DESCRIPTION
I'm trying to add mac releases (well, at least the mini version), but I'm getting an error:

```
fatal error: 'gmp.h' file not found
#include <gmp.h>
```

I've tried `brew install gmp`, but apparently that was already installed. Any ideas?