### PR TITLE
Fix nightly builds

### DIFF
--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -28,8 +28,8 @@ jobs:
                     - {name: "Linux (amd64 / mini)",    os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
                     - {name: "Linux (arm64 / mini)",    os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
                     - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
-                    #- {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
-                    #- {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
+                    - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
+                    - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
                     - {name: "macOS (amd64 / full)",    os: macOS-13,        arch: amd64, mode: full, shell: bash}
                     - {name: "macOS (amd64 / mini)",    os: macOS-13,        arch: amd64, mode: mini, shell: bash}
                     - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}
@@ -42,6 +42,7 @@ jobs:
         steps:
             - name: Get current date
               run: echo $(date -u "+%F") >> currentDate
+              shell: bash
     
             - name: "Read date"
               uses: pCYSl5EDgo/cat@master

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -120,3 +120,15 @@ jobs:
               with:
                 path: currentDate
                 trim: true
+            
+            - name: Download existing artifacts
+              uses: actions/download-artifact@v2
+              with:
+                path: ./assets
+
+            - name: Upload release assets
+              run: |
+                gh release create ${{ steps.currentDate.outputs.text }} "" ./assets/*
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -1,0 +1,51 @@
+name: Build Nightlies
+
+on:
+    push:
+        branches:
+            - '**'
+            - actions
+
+    pull_request:
+        branches:
+            - '*'
+
+    schedule:
+        - cron: '0 0 * * *'
+
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                include: 
+                    - {os: ubuntu-latest,   arch: amd64, mode: full, shell: bash}
+                    - {os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
+                    - {os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
+                    - {os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
+                    - {os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
+                    - {os: macOS-12,        arch: amd64, mode: full, shell: bash}
+                    - {os: macOS-12,        arch: amd64, mode: mini, shell: bash}
+                    - {os: macos-latest,    arch: arm64, mode: full, shell: bash}
+                    - {os: macos-latest,    arch: arm64, mode: mini, shell: bash}
+        defaults:
+            run:
+                shell: ${{ matrix.shell }}
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install Arturo
+              uses: arturo-lang/arturo-action@main
+              with: 
+                token: ${{ secrets.GITHUB_TOKEN }}
+                mode: ${{ matrix.mode }}
+                arch: ${{ matrix.arch }}
+
+            - if: matrix.os != 'ubuntu-latest' || matrix.arch != 'arm64'
+              name: Run tests
+              run: |
+                arturo -v

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -28,8 +28,8 @@ jobs:
                     - {name: "Linux (amd64 / mini)",    os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
                     - {name: "Linux (arm64 / mini)",    os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
                     - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
-                    - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
-                    - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
+                    #- {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
+                    #- {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
                     - {name: "macOS (amd64 / full)",    os: macOS-13,        arch: amd64, mode: full, shell: bash}
                     - {name: "macOS (amd64 / mini)",    os: macOS-13,        arch: amd64, mode: mini, shell: bash}
                     - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -23,20 +23,32 @@ jobs:
         strategy:
             matrix:
                 include: 
-                    - {os: ubuntu-latest,   arch: amd64, mode: full, shell: bash}
-                    - {os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
-                    - {os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
-                    - {os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
-                    - {os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
-                    - {os: macOS-12,        arch: amd64, mode: full, shell: bash}
-                    - {os: macOS-12,        arch: amd64, mode: mini, shell: bash}
-                    - {os: macos-latest,    arch: arm64, mode: full, shell: bash}
-                    - {os: macos-latest,    arch: arm64, mode: mini, shell: bash}
+                    - {name: "Linux (amd64 / full)",    os: ubuntu-latest,   arch: amd64, mode: full, shell: bash}
+                    - {name: "Linux (amd64 / safe)",    os: ubuntu-latest,   arch: amd64, mode: safe, shell: bash}
+                    - {name: "Linux (amd64 / mini)",    os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
+                    - {name: "Linux (arm64 / mini)",    os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
+                    - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
+                    - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
+                    - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
+                    - {name: "macOS (amd64 / full)",    os: macOS-12,        arch: amd64, mode: full, shell: bash}
+                    - {name: "macOS (amd64 / mini)",    os: macOS-12,        arch: amd64, mode: mini, shell: bash}
+                    - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}
+                    - {name: "macOS (arm64 / mini)",    os: macos-latest,    arch: arm64, mode: mini, shell: bash}
+
+        name: ${{ matrix.name }}
         defaults:
             run:
                 shell: ${{ matrix.shell }}
         steps:
-            - uses: actions/checkout@v4
+            - name: Get current date
+              run: echo $(date -u "+%F") >> currentDate
+    
+            - name: "Read date"
+              uses: pCYSl5EDgo/cat@master
+              id: currentDate
+              with:
+                path: currentDate
+                trim: true
 
             - name: Install Arturo
               uses: arturo-lang/arturo-action@main
@@ -44,8 +56,59 @@ jobs:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 mode: ${{ matrix.mode }}
                 arch: ${{ matrix.arch }}
-
-            - if: matrix.os != 'ubuntu-latest' || matrix.arch != 'arm64'
-              name: Run tests
+                metadata: nightly.${{ steps.currentDate.outputs.text }}
+ 
+            - if: (matrix.mode != 'safe' && matrix.mode != 'web') && (matrix.os != 'ubuntu-latest' || matrix.arch != 'arm64')
+              name: Run tests (Old)
               run: |
+                ls -la arturo
+                cd arturo 
+                cat version/metadata
                 arturo -v
+                arturo tools/tester.art
+                cd ..
+ 
+            - if: matrix.mode == 'full' && (matrix.os != 'ubuntu-latest' || matrix.arch != 'arm64')
+              name: Run tests (Unitt)
+              run: |
+                cd arturo
+                arturo tools/unitt-tester.art
+                cd ..
+
+            - name: Prepare artifact
+              id: artifact-details
+              run: |
+                binary_path="arturo/bin/arturo"
+
+                artifact_os="macos"
+                artifact_arch="${{matrix.arch}}"
+                artifact_mode="${{matrix.mode}}"
+
+                if [ "${{matrix.os}}" = "windows-latest" ]; then
+                    artifact_os="windows"
+                    binary_path="${binary_path}.exe"
+                fi
+                if [ "${{matrix.os}}" = "ubuntu-latest" ]; then
+                    artifact_os="linux"
+                    if [ "${{matrix.mode}}" = "web" ]; then
+                        artifact_os="js"
+                        artifact_arch="web"
+                        artifact_mode="mini"
+                        binary_path="${binary_path}.js"
+                    fi
+                fi
+
+                cd arturo
+                git_stamp="nightly.${{ steps.currentDate.outputs.text }}"
+                cd ..
+
+                artifact_name="arturo-${git_stamp}-${artifact_arch}-${artifact_os}-${artifact_mode}"
+
+                echo "BINARY_PATH=$binary_path" >> "$GITHUB_OUTPUT"
+                echo "ARTIFACT_NAME=$artifact_name" >> "$GITHUB_OUTPUT"
+
+            - name: Upload artifact
+              uses: 'actions/upload-artifact@v4'
+              with:
+                name: ${{ steps.artifact-details.outputs.ARTIFACT_NAME }}
+                path: ${{ steps.artifact-details.outputs.BINARY_PATH }}

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -64,23 +64,6 @@ jobs:
                 mode: ${{ matrix.mode }}
                 arch: ${{ matrix.arch }}
                 metadata: nightly.${{ steps.currentDate.outputs.text }}
- 
-            - if: (matrix.mode != 'safe' && matrix.mode != 'web') && (matrix.os != 'ubuntu-latest' || matrix.arch != 'arm64')
-              name: Run tests (Old)
-              run: |
-                ls -la arturo
-                cd arturo 
-                cat version/metadata
-                arturo -v
-                arturo tools/tester.art
-                cd ..
- 
-            - if: matrix.mode == 'full' && (matrix.os != 'ubuntu-latest' || matrix.arch != 'arm64')
-              name: Run tests (Unitt)
-              run: |
-                cd arturo
-                arturo tools/unitt-tester.art
-                cd ..
 
             - name: Prepare artifact
               id: artifact-details

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -28,8 +28,8 @@ jobs:
                     - {name: "Linux (amd64 / mini)",    os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
                     - {name: "Linux (arm64 / mini)",    os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
                     - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
-                    #- {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
-                    #- {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
+                    - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
+                    - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
                     - {name: "macOS (amd64 / full)",    os: macOS-12,        arch: amd64, mode: full, shell: bash}
                     - {name: "macOS (amd64 / mini)",    os: macOS-12,        arch: amd64, mode: mini, shell: bash}
                     - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -125,4 +125,15 @@ jobs:
         runs-on: ubuntu-latest
         if: (github.event_name == 'schedule' ) || (github.event_name == 'workflow_dispatch')
         needs:
-          - build
+            - build
+        steps:
+            - name: Get current date
+              run: echo $(date -u "+%F") >> currentDate
+              shell: bash
+    
+            - name: "Read date"
+              uses: pCYSl5EDgo/cat@master
+              id: currentDate
+              with:
+                path: currentDate
+                trim: true

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -17,12 +17,14 @@ on:
     schedule:
         - cron: '0 0 * * *'
 
+    workflow_dispatch:
+
 concurrency: 
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    test:
+    build:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
@@ -117,3 +119,10 @@ jobs:
               with:
                 name: ${{ steps.artifact-details.outputs.ARTIFACT_NAME }}
                 path: ${{ steps.artifact-details.outputs.BINARY_PATH }}
+    
+    release:
+        name: "Release"
+        runs-on: ubuntu-latest
+        if: (github.event_name == 'schedule' ) || (github.event_name == 'workflow_dispatch')
+        needs:
+          - build

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -30,8 +30,8 @@ jobs:
                     - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
                     - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
                     - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
-                    - {name: "macOS (amd64 / full)",    os: macOS-13,        arch: amd64, mode: full, shell: bash}
-                    - {name: "macOS (amd64 / mini)",    os: macOS-13,        arch: amd64, mode: mini, shell: bash}
+                    - {name: "macOS (amd64 / full)",    os: macos-13,        arch: amd64, mode: full, shell: bash}
+                    - {name: "macOS (amd64 / mini)",    os: macos-13,        arch: amd64, mode: mini, shell: bash}
                     - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}
                     - {name: "macOS (arm64 / mini)",    os: macos-latest,    arch: arm64, mode: mini, shell: bash}
 

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -28,8 +28,8 @@ jobs:
                     - {name: "Linux (amd64 / mini)",    os: ubuntu-latest,   arch: amd64, mode: mini, shell: bash}
                     - {name: "Linux (arm64 / mini)",    os: ubuntu-latest,   arch: arm64, mode: mini, shell: bash}
                     - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
-                    - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
-                    - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
+                    #- {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
+                    #- {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
                     - {name: "macOS (amd64 / full)",    os: macOS-12,        arch: amd64, mode: full, shell: bash}
                     - {name: "macOS (amd64 / mini)",    os: macOS-12,        arch: amd64, mode: mini, shell: bash}
                     - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -30,8 +30,8 @@ jobs:
                     - {name: "JS (web / mini)",         os: ubuntu-latest,   arch: amd64, mode: web,  shell: bash}
                     - {name: "Windows (amd64 / full)",  os: windows-latest,  arch: amd64, mode: full, shell: "msys2 {0}"}
                     - {name: "Windows (amd64 / mini)",  os: windows-latest,  arch: amd64, mode: mini, shell: "msys2 {0}"}
-                    - {name: "macOS (amd64 / full)",    os: macOS-12,        arch: amd64, mode: full, shell: bash}
-                    - {name: "macOS (amd64 / mini)",    os: macOS-12,        arch: amd64, mode: mini, shell: bash}
+                    - {name: "macOS (amd64 / full)",    os: macOS-13,        arch: amd64, mode: full, shell: bash}
+                    - {name: "macOS (amd64 / mini)",    os: macOS-13,        arch: amd64, mode: mini, shell: bash}
                     - {name: "macOS (arm64 / full)",    os: macos-latest,    arch: arm64, mode: full, shell: bash}
                     - {name: "macOS (arm64 / mini)",    os: macos-latest,    arch: arm64, mode: mini, shell: bash}
 

--- a/.github/workflows/buildnightlies.yml
+++ b/.github/workflows/buildnightlies.yml
@@ -3,12 +3,16 @@ name: Build Nightlies
 on:
     push:
         branches:
+            - 'master'
+            - 'actions'
+        tags-ignore:
             - '**'
-            - actions
-
     pull_request:
-        branches:
-            - '*'
+        paths-ignore:
+            - 'docs/*'
+            - '*.yml'
+            - '*.md'
+            - 'LICENSE'
 
     schedule:
         - cron: '0 0 * * *'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "arturo"]
-	path = arturo
-	url = https://github.com/arturo-lang/arturo.git


### PR DESCRIPTION
Since we now how have a brand-new (and working) [Arturo action](https://github.com/arturo-lang/arturo-action) - which actually uses our master branch to produce binaries, the most DRY way to have nightly builds would be to simply use that action (and perhaps, back-feed the action with the Nightly builds, and serve these ones - if requested - but... let's say that's for future reference! 🚀 )

Fixes: #4 

Also see: #7 