### PR TITLE
Make sure tag/release is overwritten when re-building

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,6 +142,8 @@ jobs:
             - name: Upload release assets
               run: |
                 BODY="**Commit:** [\`${{ needs.Prepare.outputs.git_sha }}\`](https://github.com/arturo-lang/arturo/commit/${{ needs.Prepare.outputs.git_sha }})"
+
+                gh release delete "${{ needs.Prepare.outputs.date_hyphenated }}" --yes --cleanup-tag 2>/dev/null || true
                 
                 gh release create "${{ needs.Prepare.outputs.date_hyphenated }}" \
                   --title "${{ needs.Prepare.outputs.date_hyphenated }}" \


### PR DESCRIPTION
Right now, we can trigger a build manually (for whatever reason, e.g. if the previous build didn't succeed, etc).
But if the tag has already been created, it means the new build will fail.

This is what we'll be fixing here! 🚀 